### PR TITLE
Improve responsive layout and menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,18 +18,21 @@
             <a href="#" aria-label="TikTok"><img src="assets/socials/social-tiktok_icon.svg" alt="" aria-hidden="true"></a>
             <a href="#" aria-label="YouTube"><img src="assets/socials/social-youtube_icon.svg" alt="" aria-hidden="true"></a>
         </nav>
-        <button id="hamburger" aria-controls="hamburgerMenu" aria-expanded="false">☰</button>
+        <button id="hamburger" aria-controls="hamburgerMenu" aria-expanded="false" aria-label="Menu">☰</button>
         <div id="hamburgerMenu" role="menu" aria-hidden="true">
-            <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-x_icon.svg" alt="X"> X</a>
-            <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-linkedin_icon.svg" alt="LinkedIn"> LinkedIn</a>
-            <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-whatsapp_icon.svg" alt="WhatsApp"> WhatsApp</a>
-            <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-pinterest_icon.svg" alt="Pinterest"> Pinterest</a>
-            <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-discord_icon.svg" alt="Discord"> Discord</a>
-            <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-google_icon.svg" alt="Google"> Google</a>
-            <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-behance_icon.svg" alt="Behance"> Behance</a>
-            <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-shazam_icon.svg" alt="Shazam"> Shazam</a>
-            <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-snapchat_icon.svg" alt="Snapchat"> Snapchat</a>
-            <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-itunes_icon.svg" alt="iTunes"> iTunes</a>
+            <button class="close-menu" aria-label="Close menu">✕</button>
+            <div class="menu-links">
+                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-x_icon.svg" alt="X"> X</a>
+                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-linkedin_icon.svg" alt="LinkedIn"> LinkedIn</a>
+                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-whatsapp_icon.svg" alt="WhatsApp"> WhatsApp</a>
+                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-pinterest_icon.svg" alt="Pinterest"> Pinterest</a>
+                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-discord_icon.svg" alt="Discord"> Discord</a>
+                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-google_icon.svg" alt="Google"> Google</a>
+                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-behance_icon.svg" alt="Behance"> Behance</a>
+                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-shazam_icon.svg" alt="Shazam"> Shazam</a>
+                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-snapchat_icon.svg" alt="Snapchat"> Snapchat</a>
+                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-itunes_icon.svg" alt="iTunes"> iTunes</a>
+            </div>
         </div>
     </header>
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -5,25 +5,23 @@
     box-sizing: border-box;
 }
 
+html {
+    font-size: clamp(8px, 1.2vw, 16px);
+}
+
 /* Grid Layout */
+/* Always show at least three columns */
 .grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
     gap: var(--gap);
     max-width: var(--grid-max);
     width: 100%;
     margin: 0 auto;
-    padding: 1rem;
+    padding: var(--gap);
 }
 
-/* Force 3 cards per row on tablets/mobiles */
-@media (max-width: 1023px) {
-    .grid {
-        grid-template-columns: repeat(3, 1fr);
-    }
-}
-
-/* Force 4 cards per row on desktops */
+/* Four columns on wider screens */
 @media (min-width: 1024px) {
     .grid {
         grid-template-columns: repeat(4, 1fr);
@@ -33,19 +31,19 @@
 .description {
     max-width: var(--description-max-width);
     margin: var(--description-margin);
-    padding: var(--description-padding);
+    padding: clamp(1rem, 5vw, 2rem);
     border-radius: var(--description-border-radius);
     color: white;
 }
 
 .description h1 {
-    font-size: 2rem;
+    font-size: clamp(1.2rem, 5vw, 2rem);
     margin-bottom: 1rem;
     font-weight: 800;
 }
 
 .description p {
-    font-size: 1.1rem;
+    font-size: clamp(0.9rem, 3vw, 1.1rem);
     opacity: 0.9;
     max-width: 600px;
     margin: 0 auto;
@@ -86,7 +84,6 @@
 
 body {
     font-family: var(--font-body);
-    font-size: calc(16px * var(--font-scale));
     line-height: 1.5;
     color: var(--text);
     background: var(--creator-bg);
@@ -130,7 +127,7 @@ body[data-gradient="true"] {
 }
 
 #handle {
-    font-size: var(--handle-size);
+    font-size: clamp(1rem, 4vw, 1.25rem);
     font-weight: 600;
 }
 
@@ -148,8 +145,8 @@ body[data-gradient="true"] {
 }
 
 .header-links img {
-    width: 24px;
-    height: 24px;
+    width: clamp(24px, 6vw, 32px);
+    height: clamp(24px, 6vw, 32px);
 }
 
 #hamburger {
@@ -158,7 +155,7 @@ body[data-gradient="true"] {
     border: none;
     color: var(--text);
     cursor: pointer;
-    font-size: 24px;
+    font-size: clamp(2rem, 8vw, 2.5rem);
 }
 
 #hamburgerMenu {
@@ -171,97 +168,37 @@ body[data-gradient="true"] {
     border-radius: var(--creator-card-radius);
     max-height: clamp(60vh, 80vh, 80vh);
     width: min(300px, 85vw);
-    overflow-y: auto;
+    display: none;
     margin: 1rem;
-    padding: 1rem 0;
+    padding: 0;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
     border: 1px solid rgba(255, 255, 255, 0.1);
     scrollbar-width: thin;
     scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
-    display: none;
-    margin: 1rem;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+    overflow: hidden;
+    flex-direction: column;
 }
 
-/* Card and Title Styles */
-.card-footer {
-    padding: 1rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 1rem;
-    background: rgba(255, 255, 255, 0.95);
-    min-height: calc(2.6em + 2rem); /* 2 lines + padding */
-}
-
-.title {
-    margin: 0;
-    font-size: calc(1rem * var(--font-scale));
-    font-weight: var(--title-font-weight);
+#hamburgerMenu .close-menu {
+    align-self: flex-end;
+    background: none;
+    border: none;
     color: var(--text);
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    min-height: 2.6em;
-    line-height: 1.3;
-    flex: 1;
-    word-break: break-word;
-    hyphens: auto;
+    font-size: clamp(1.25rem, 4vw, 1.75rem);
+    cursor: pointer;
+    padding: 0.5rem 1rem;
 }
 
-.badge {
-    font-size: 0.75rem;
-    font-weight: 600;
-    padding: 0.25rem 0.5rem;
-    border-radius: 1rem;
-    background: var(--creator-gradient);
-    color: white;
+#hamburgerMenu .menu-links {
     display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    flex-shrink: 0;
+    flex-direction: column;
+    overflow-y: auto;
+    padding: 1rem 0;
+    flex: 1;
 }
-
-.badge img {
-    width: 16px;
-    height: 16px;
-}
-
-.card {
-    position: relative;
-    border-radius: var(--creator-card-radius);
-    overflow: hidden;
-    background: white;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    transition: transform 0.2s ease-out, box-shadow 0.2s ease-out;
-    display: block;
-    text-decoration: none;
-}
-
-.card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-}
-
-.card:active {
-    box-shadow: 0 0 0 2px var(--rim) inset;
-}
-
-.card .thumb {
-    width: 100%;
-    aspect-ratio: 742/960;
-    object-fit: cover;
-    display: block;
-    background: #f5f5f5;
-}
-    
 
 #hamburgerMenu.visible {
-    display: block;
+    display: flex;
 }
 
 #hamburgerMenu a {
@@ -335,50 +272,6 @@ body[data-gradient="true"] {
     height: 18px;
 }
 
-/* Grid */
-.grid {
-    display: grid;
-    gap: var(--gap);
-    padding: var(--gap);
-    max-width: var(--grid-max);
-    margin: 0 auto;
-    flex: 1;
-    width: 100%;
-    box-sizing: border-box;
-}
-
-/* Mobile first approach */
-@media screen and (max-width: 639px) {
-    .grid {
-        grid-template-columns: 1fr;
-        gap: 1rem;
-        padding: 1rem;
-    }
-}
-
-/* Small tablets */
-@media screen and (min-width: 640px) and (max-width: 767px) {
-    .grid {
-        grid-template-columns: repeat(2, 1fr);
-        gap: 1rem;
-    }
-}
-
-/* Large tablets and small desktops */
-@media screen and (min-width: 768px) and (max-width: 1023px) {
-    .grid {
-        grid-template-columns: repeat(3, 1fr);
-    }
-}
-
-/* Larger desktops */
-@media screen and (min-width: 1024px) {
-    .grid {
-        grid-template-columns: repeat(4, 1fr);
-        padding: var(--gap) max(var(--gap), calc((100% - var(--grid-max)) / 2));
-    }
-}
-
 /* Cards */
 .card {
     position: relative;
@@ -417,12 +310,13 @@ body[data-gradient="true"] {
     padding: 1rem;
     display: flex;
     align-items: flex-start;
+    justify-content: space-between;
     gap: 0.5rem;
 }
 
 .title {
     flex: 1;
-    font-size: 0.9rem;
+    font-size: clamp(0.8rem, 2vw, 0.9rem);
     display: -webkit-box;
     -webkit-line-clamp: 2;
     line-clamp: 2;
@@ -439,6 +333,11 @@ body[data-gradient="true"] {
     font-size: 0.75rem;
     font-weight: 600;
     background: var(--creator-gradient);
+}
+
+.badge img {
+    width: 16px;
+    height: 16px;
 }
 
 .icon-btn {
@@ -602,6 +501,11 @@ body[data-gradient="true"] {
     border-radius: 4px;
     background: rgba(255, 255, 255, 0.1);
     color: var(--text);
+}
+
+#reportMessage {
+    min-height: 6rem;
+    resize: none;
 }
 
 .modal-buttons {

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -20,7 +20,6 @@
     /* Typography */
     --font-body: 'Inter', system-ui, sans-serif;
     --font-heading: var(--font-body);
-    --font-scale: 1.0;
     --handle-size: 20px;
     --logo-size: 64px;
 
@@ -46,7 +45,7 @@
     --footer-shadow: 0 -1px 0 rgba(255, 255, 255, 0.1);
 
     /* Cards */
-    --card-bg: rgba(255, 255, 255, 0.1);
+    --card-bg: #1e1e1e;
     --card-hover-lift: translateY(-2px);
     --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     --card-hover-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);

--- a/src/js/reports.js
+++ b/src/js/reports.js
@@ -9,20 +9,21 @@ const form = document.getElementById('reportForm');
 function showMenu(card, button) {
     if (isCardReported(card.dataset.uid)) return;
 
-    const rect = button.getBoundingClientRect();
-    menu.style.top = `${rect.bottom + window.scrollY + 8}px`;
-    menu.style.left = `${rect.left + window.scrollX}px`;
-    menu.classList.add('visible');
     activeCard = card;
-    
-    // Close menu when clicking outside
+    card.appendChild(menu);
+    menu.classList.add('visible');
+    menu.style.top = `${button.offsetTop + button.offsetHeight + 8}px`;
+    menu.style.right = '0.5rem';
+    menu.style.left = '0.5rem';
+
+    // Close menu when clicking outside the card
     const closeMenu = (e) => {
-        if (!menu.contains(e.target) && !button.contains(e.target)) {
+        if (!card.contains(e.target)) {
             menu.classList.remove('visible');
             document.removeEventListener('click', closeMenu);
         }
     };
-    
+
     document.addEventListener('click', closeMenu);
 }
 
@@ -90,7 +91,7 @@ export function initializeReports() {
 
     // Close modal on backdrop click or escape
     modal.addEventListener('click', e => {
-        if (e.target === modal) {
+        if (e.target === modal || e.target.classList.contains('btn-cancel')) {
             modal.classList.remove('visible');
         }
     });

--- a/src/js/ui-header.js
+++ b/src/js/ui-header.js
@@ -2,31 +2,35 @@
 export function initializeHeader() {
     const hamburgerBtn = document.getElementById('hamburger');
     const hamburgerMenu = document.getElementById('hamburgerMenu');
+    const closeBtn = hamburgerMenu?.querySelector('.close-menu');
 
-    if (hamburgerBtn && hamburgerMenu) {
+    if (hamburgerBtn && hamburgerMenu && closeBtn) {
+        const toggleMenu = (show) => {
+            hamburgerMenu.classList.toggle('visible', show);
+            hamburgerBtn.setAttribute('aria-expanded', show);
+            hamburgerMenu.setAttribute('aria-hidden', !show);
+            hamburgerBtn.textContent = show ? '✕' : '☰';
+        };
+
         hamburgerBtn.addEventListener('click', (e) => {
             e.stopPropagation();
             const isExpanded = hamburgerBtn.getAttribute('aria-expanded') === 'true';
-            hamburgerBtn.setAttribute('aria-expanded', !isExpanded);
-            hamburgerMenu.classList.toggle('visible');
-            hamburgerMenu.setAttribute('aria-hidden', isExpanded);
+            toggleMenu(!isExpanded);
         });
+
+        closeBtn.addEventListener('click', () => toggleMenu(false));
 
         // Close menu when clicking outside
         document.addEventListener('click', (e) => {
             if (!hamburgerMenu.contains(e.target) && !hamburgerBtn.contains(e.target)) {
-                hamburgerMenu.classList.remove('visible');
-                hamburgerBtn.setAttribute('aria-expanded', 'false');
-                hamburgerMenu.setAttribute('aria-hidden', 'true');
+                toggleMenu(false);
             }
         });
 
         // Close on Escape key
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape' && hamburgerMenu.classList.contains('visible')) {
-                hamburgerMenu.classList.remove('visible');
-                hamburgerBtn.setAttribute('aria-expanded', 'false');
-                hamburgerMenu.setAttribute('aria-hidden', 'true');
+                toggleMenu(false);
             }
         });
     }


### PR DESCRIPTION
## Summary
- Increase header icon and hamburger sizes for better mobile usability.
- Force grid to maintain three-column minimum and add horizontal padding.
- Reposition report dropdown inside cards and expand report message field.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3cc320fe08325a9237ee29b4d6be7