### PR TITLE
feat: load profile and links config

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,48 +8,35 @@
     <link rel="stylesheet" href="/src/css/styles.css">
 </head>
 <body>
-    <header class="header h1">
-        <div class="header-left">
-            <img id="logo" src="assets/logo.png" alt="Creator Logo" />
-            <span id="handle">@creator</span>
-        </div>
-        <nav class="header-links">
-            <a href="#" aria-label="Instagram"><img src="assets/socials/social-instagram_icon.svg" alt="" aria-hidden="true"></a>
-            <a href="#" aria-label="TikTok"><img src="assets/socials/social-tiktok_icon.svg" alt="" aria-hidden="true"></a>
-            <a href="#" aria-label="YouTube"><img src="assets/socials/social-youtube_icon.svg" alt="" aria-hidden="true"></a>
-        </nav>
-        <button id="hamburger" aria-controls="hamburgerMenu" aria-expanded="false" aria-label="Menu">☰</button>
-        <div id="hamburgerMenu" role="menu" aria-hidden="true">
-            <button class="close-menu" aria-label="Close menu">✕</button>
-            <div class="menu-links">
-                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-x_icon.svg" alt="X"> X</a>
-                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-linkedin_icon.svg" alt="LinkedIn"> LinkedIn</a>
-                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-whatsapp_icon.svg" alt="WhatsApp"> WhatsApp</a>
-                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-pinterest_icon.svg" alt="Pinterest"> Pinterest</a>
-                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-discord_icon.svg" alt="Discord"> Discord</a>
-                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-google_icon.svg" alt="Google"> Google</a>
-                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-behance_icon.svg" alt="Behance"> Behance</a>
-                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-shazam_icon.svg" alt="Shazam"> Shazam</a>
-                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-snapchat_icon.svg" alt="Snapchat"> Snapchat</a>
-                <a href="#" target="_blank" rel="noopener"><img src="assets/socials/social-itunes_icon.svg" alt="iTunes"> iTunes</a>
+    <header class="header">
+        <div class="header-content">
+            <div class="branding">
+                <img id="logo" src="" alt="">
+                <span id="handle"></span>
             </div>
+            <div class="nav-container">
+                <nav class="quick-links"></nav>
+                <button id="hamburger" aria-label="Menu" aria-expanded="false" aria-controls="hamburgerMenu">☰</button>
+            </div>
+        </div>
+        <div id="hamburgerMenu" class="overflow-menu" aria-hidden="true">
+            <button class="close-menu" aria-label="Close menu">✕</button>
+            <nav class="overflow-links"></nav>
         </div>
     </header>
 
-    <div class="description style-1 align-center">
-        <h1>Welcome to My Creative Space</h1>
-        <p>Explore my latest content from Instagram and TikTok. Feel free to browse through my curated collection of posts and connect with me on various social platforms.</p>
-        <a href="https://creativespase.com" class="create-link" target="_blank" rel="noopener">
-        <em>Create your own creative space</em>
-    </a>
+    <div class="description" data-sticky="false">
+        <h1></h1>
+        <p></p>
+        <a href="/signup" class="marketing-link" style="display: none;"></a>
     </div>
 
     <div class="filters" role="tablist" aria-label="Source filter">
         <button class="pill active" role="tab" aria-pressed="true" data-filter="ig">
-            <img src="assets/socials/social-instagram_icon.svg" class="icon" alt="" aria-hidden="true"> Instagram
+            <img src="/assets/icons/social-instagram_icon.svg" class="icon" alt="" aria-hidden="true"> Instagram
         </button>
         <button class="pill" role="tab" aria-pressed="false" data-filter="tt">
-            <img src="assets/socials/social-tiktok_icon.svg" class="icon" alt="" aria-hidden="true"> TikTok
+            <img src="/assets/icons/social-tiktok_icon.svg" class="icon" alt="" aria-hidden="true"> TikTok
         </button>
     </div>
 
@@ -57,19 +44,10 @@
         <!-- Cards will be populated by JS -->
     </main>
 
-    <footer class="footer f1">
-        <div class="footer-links">
-            <a href="#" target="_blank" rel="noopener" aria-label="WhatsApp"><img src="assets/socials/social-whatsapp_icon.svg" alt=""></a>
-            <a href="#" target="_blank" rel="noopener" aria-label="Instagram"><img src="assets/socials/social-instagram_icon.svg" alt=""></a>
-            <a href="#" target="_blank" rel="noopener" aria-label="TikTok"><img src="assets/socials/social-tiktok_icon.svg" alt=""></a>
-            <a href="#" target="_blank" rel="noopener" aria-label="YouTube"><img src="assets/socials/social-youtube_icon.svg" alt=""></a>
-            <a href="#" target="_blank" rel="noopener" aria-label="LinkedIn"><img src="assets/socials/social-linkedin_icon.svg" alt=""></a>
-        </div>
-        <div class="footer-legal">
-            <a href="#" target="_blank" rel="noopener">Privacy Policy</a>
-            <a href="#" target="_blank" rel="noopener">Create Account</a>
-        </div>
-        <em class="copyright">All logos are property of their respective owners.</em>
+    <footer class="footer">
+        <div class="footer-links"></div>
+        <div class="footer-legal"></div>
+        <div class="copyright"></div>
     </footer>
 
     <!-- Report Modal -->
@@ -99,8 +77,5 @@
 
     <button id="backToTop" aria-label="Back to top" class="back-to-top">↑</button>
     <script type="module" src="/src/js/main.js"></script>
-    
 </body>
 </html>
-
-

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -89,14 +89,16 @@ html {
 
 .title {
     margin: 0;
-    font-size: clamp(0.9rem, 2vw, 1.2rem);
+    font-size: var(--card-title-size, clamp(0.9rem, 2vw, 1.2rem));
+    font-weight: var(--card-title-weight, 600);
     line-height: 1.35;
     display: -webkit-box;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: var(--card-title-lines, 2);
     -webkit-box-orient: vertical;
     overflow: hidden;
-    min-height: calc(2 * 1.35em);
-    max-height: calc(2 * 1.35em);
+    color: var(--card-title-color, inherit);
+    min-height: calc(var(--card-title-lines, 2) * 1.35em);
+    max-height: calc(var(--card-title-lines, 2) * 1.35em);
 }
 
 
@@ -212,6 +214,7 @@ body[data-gradient="true"] {
     position: sticky;
     top: 0;
     z-index: 100;
+    height: var(--hdr-h);
     padding: 1rem max(1rem, calc((100% - var(--grid-max)) / 2));
     background: var(--header-bg);
     backdrop-filter: blur(var(--header-blur));
@@ -223,7 +226,7 @@ body[data-gradient="true"] {
     margin-bottom: 1rem;
 }
 
-.header-left {
+.branding {
     display: flex;
     align-items: center;
     gap: 1rem;
@@ -241,20 +244,20 @@ body[data-gradient="true"] {
     font-weight: 600;
 }
 
-.header-links {
+.quick-links {
     display: flex;
     gap: 1rem;
     margin-left: auto;
 }
 
-.header-links a {
+.quick-links a {
     display: flex;
     align-items: center;
     color: var(--text);
     text-decoration: none;
 }
 
-.header-links img {
+.quick-links img {
     width: clamp(24px, 6vw, 32px);
     height: clamp(24px, 6vw, 32px);
 }
@@ -299,7 +302,7 @@ body[data-gradient="true"] {
     padding: 0.5rem 1rem;
 }
 
-#hamburgerMenu .menu-links {
+#hamburgerMenu .overflow-links {
     display: flex;
     flex-direction: column;
     overflow-y: auto;
@@ -510,6 +513,7 @@ body[data-gradient="true"] {
     border-top: 1px solid var(--footer-bd);
     text-align: center;
     width: 100%;
+    height: var(--ftr-h);
     position: fixed; /* Changed to fixed */
     bottom: 0;
     z-index: 1000;
@@ -546,6 +550,8 @@ body[data-gradient="true"] {
     justify-content: center;
     gap: 2rem;
     margin-bottom: 1rem;
+    font-size: var(--footer-font-size, 0.95rem);
+    font-weight: var(--footer-font-weight, 500);
 }
 
 .footer-legal a {

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -22,6 +22,8 @@
     --font-heading: var(--font-body);
     --handle-size: 20px;
     --logo-size: 64px;
+    --hdr-h: 64px;
+    --ftr-h: 80px;
 
     /* Layout */
     --header-bg: rgba(255, 255, 255, 0.1);

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -191,18 +191,6 @@ const mocktitles = [
 
 
 
-// Mock profile data
-const mockProfile = {
-    handle: '@creator',
-    links: {
-        instagram: 'https://instagram.com/creator',
-        tiktok: 'https://tiktok.com/@creator',
-        youtube: 'https://youtube.com/@creator',
-        whatsapp: 'https://wa.me/1234567890',
-        linkedin: 'https://linkedin.com/in/creator'
-    }
-};
-
 // Generate random mock cards
 function generateMockCards(count = 200000) {
     return Array.from({ length: count }, (_, i) => ({
@@ -218,9 +206,31 @@ function generateMockCards(count = 200000) {
 // Mock API calls
 export async function getPublicProfile() {
     console.log('Fetching public profile...');
-    // Simulate network delay
-    await new Promise(resolve => setTimeout(resolve, 300));
-    return mockProfile;
+    const res = await fetch('/config/profile.json');
+    if (!res.ok) throw new Error('Failed to load profile');
+    return res.json();
+}
+
+export async function getLinksConfig() {
+    console.log('Fetching links config...');
+    const res = await fetch('/config/links.json');
+    if (!res.ok) throw new Error('Failed to load links');
+    const data = await res.json();
+    const isValid = href => typeof href === 'string' && href.length <= 2048 && (
+        href.startsWith('https://') || href.startsWith('mailto:') || href.startsWith('tel:')
+    );
+    const filter = arr => Array.isArray(arr) ? arr.filter(l => isValid(l.href)) : [];
+    if (data.header) {
+        data.header.quick = filter(data.header.quick).slice(0, 3);
+        data.header.overflow = filter(data.header.overflow);
+    }
+    if (data.footer) {
+        data.footer.icons = filter(data.footer.icons);
+        if (Array.isArray(data.footer.text_links)) {
+            data.footer.text_links = data.footer.text_links.filter(l => isValid(l.href));
+        }
+    }
+    return data;
 }
 
 export async function getPublicCards() {

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -1,4 +1,5 @@
 import { getReportedCards } from './beacon.js';
+import { applyTheme } from './theme.js';
 
 // State management
 let state = {
@@ -7,7 +8,8 @@ let state = {
     currentFilter: 'ig', // Default to Instagram
     currentPage: 0,
     reportedCards: getReportedCards(), // Initialize from localStorage
-    profile: null
+    profile: null,
+    linksConfig: null
 };
 
 // Debug state changes
@@ -21,6 +23,7 @@ export const getPinnedCards = () => state.pinnedCards;
 export const getCurrentFilter = () => state.currentFilter;
 export const getCurrentPage = () => state.currentPage;
 export const getProfile = () => state.profile;
+export const getLinksConfig = () => state.linksConfig;
 export const isCardReported = (uid) => state.reportedCards.has(uid);
 
 // Setters
@@ -52,4 +55,12 @@ export const markCardReported = (uid) => {
 export const setProfile = (profile) => {
     logStateChange('setProfile', { handle: profile.handle });
     state.profile = profile;
+    applyTheme(profile);
 };
+
+export const setLinksConfig = (links) => {
+    logStateChange('setLinksConfig', {});
+    state.linksConfig = links;
+};
+
+export const APP_STATE = state;

--- a/src/js/theme.js
+++ b/src/js/theme.js
@@ -1,16 +1,126 @@
 // Theme initialization and management
 export function initializeTheme() {
-    // Set initial gradient state
-    document.body.dataset.gradient = '1';
-    
-    // Load fonts
     loadFonts();
 }
 
+export function applyTheme(profile) {
+    if (!profile) return;
+    const root = document.documentElement;
+
+    // Brand colors
+    root.style.setProperty('--brand-primary', profile.brand.primary);
+    root.style.setProperty('--brand-secondary', profile.brand.secondary);
+    root.style.setProperty('--brand-tertiary', profile.brand.tertiary);
+    root.style.setProperty('--brand-text', profile.brand.text);
+
+    // Base colors
+    root.style.setProperty('--creator-bg', profile.colors.page_bg);
+    root.style.setProperty('--creator-gradient', profile.colors.gradient);
+    root.style.setProperty('--accent', profile.colors.accent);
+    root.style.setProperty('--text', profile.colors.header_text);
+    root.style.setProperty('--text-muted', profile.colors.desc_body_text);
+
+    // Glass surfaces
+    const hGlass = profile.surfaces.header.glass;
+    root.style.setProperty('--header-bg', `rgba(255,255,255,${hGlass.opacity})`);
+    root.style.setProperty('--header-blur', `${hGlass.blur_px}px`);
+    const fGlass = profile.surfaces.footer.glass;
+    root.style.setProperty('--footer-bg', `rgba(0,0,0,${fGlass.opacity})`);
+    root.style.setProperty('--footer-blur', `${fGlass.blur_px}px`);
+
+    // Sizes
+    root.style.setProperty('--hdr-h', profile.sizes.header_height_px + 'px');
+    root.style.setProperty('--footer-padding-y', profile.sizes.footer_padding_y_px + 'px');
+    root.style.setProperty('--logo-size', profile.sizes.logo_px + 'px');
+    const ftrH = profile.sizes.footer_padding_y_px * 2 + 20;
+    root.style.setProperty('--ftr-h', ftrH + 'px');
+
+    // Typography variables
+    root.style.setProperty('--card-title-size', profile.typography.card_title_rem + 'rem');
+    root.style.setProperty('--card-title-weight', profile.typography.card_title_weight);
+    root.style.setProperty('--card-title-lines', profile.clamp.card_title_lines);
+    root.style.setProperty('--footer-font-size', profile.typography.footer_rem + 'rem');
+    root.style.setProperty('--footer-font-weight', profile.typography.footer_weight);
+    root.style.setProperty('--card-title-color', profile.colors.card_title_text);
+
+    // Header text
+    const handle = document.getElementById('handle');
+    if (handle) {
+        handle.textContent = `@${profile.handle}`;
+        handle.style.fontSize = profile.typography.header_rem + 'rem';
+        handle.style.fontWeight = profile.typography.header_weight;
+        handle.style.color = profile.colors.header_text;
+    }
+
+    // Description
+    const desc = document.querySelector('.description');
+    if (desc) {
+        desc.style.display = profile.description.visible ? '' : 'none';
+        desc.dataset.sticky = profile.description.sticky ? 'true' : 'false';
+        desc.classList.toggle('align-center', profile.layout.description_align === 'center');
+        desc.classList.toggle('align-left', profile.layout.description_align === 'left');
+        if (profile.surfaces.desc_band.mode === 'gradient') {
+            desc.style.background = profile.colors.desc_band_bg;
+        } else if (profile.surfaces.desc_band.mode === 'image') {
+            const img = profile.surfaces.desc_band.image;
+            if (img?.url) {
+                desc.style.backgroundImage = `url(${img.url})`;
+                desc.style.backgroundSize = img.fit || 'cover';
+                desc.style.backgroundPosition = img.pos || 'center';
+                desc.style.backgroundRepeat = 'no-repeat';
+            }
+        }
+        const title = desc.querySelector('h1');
+        const body = desc.querySelector('p');
+        const link = desc.querySelector('.marketing-link');
+        if (title) {
+            title.textContent = profile.description.title || '';
+            title.style.fontSize = profile.typography.desc_title_rem + 'rem';
+            title.style.fontWeight = profile.typography.desc_title_weight;
+            title.style.color = profile.colors.desc_title_text;
+            title.style.display = '-webkit-box';
+            title.style.webkitLineClamp = profile.clamp.tiny_desc_lines;
+        }
+        if (body) {
+            body.textContent = profile.description.body || '';
+            body.style.fontSize = profile.typography.desc_body_rem + 'rem';
+            body.style.fontWeight = profile.typography.desc_body_weight;
+            body.style.color = profile.colors.desc_body_text;
+            body.style.display = '-webkit-box';
+            body.style.webkitLineClamp = profile.clamp.desc_body_lines;
+        }
+        if (link) {
+            if (profile.description.marketing_link?.show) {
+                link.textContent = profile.description.marketing_link.text;
+                link.style.display = '';
+                link.style.color = 'var(--accent)';
+            } else {
+                link.style.display = 'none';
+            }
+        }
+    }
+
+    const quick = document.querySelector('.quick-links');
+    if (quick) {
+        quick.style.justifyContent = profile.layout.header_quick_alignment;
+    }
+
+    // Footer color
+    const footer = document.querySelector('.footer');
+    if (footer) {
+        footer.style.color = profile.colors.footer_text;
+    }
+
+    // Body gradient toggle
+    if (profile.colors.gradient) {
+        document.body.dataset.gradient = 'true';
+    }
+}
+
 async function loadFonts() {
-    // Load Inter font
     const fontLink = document.createElement('link');
     fontLink.href = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap';
     fontLink.rel = 'stylesheet';
     document.head.appendChild(fontLink);
 }
+

--- a/src/js/ui-header.js
+++ b/src/js/ui-header.js
@@ -1,19 +1,59 @@
 // Header functionality
 import { trackHeaderLinkClick } from './analytics.js';
+import { getLinksConfig } from './api.js';
+import { setLinksConfig } from './state.js';
+import { initializeFooter } from './ui-footer.js';
+
+function createLink(link, basePath, withTitle = false) {
+    const a = document.createElement('a');
+    a.href = link.href;
+    if (link.href.startsWith('https://')) {
+        a.target = '_blank';
+        a.rel = 'noopener';
+    }
+    a.setAttribute('aria-label', link.aria);
+
+    const img = document.createElement('img');
+    img.src = `${basePath}${link.icon}.svg`;
+    img.alt = '';
+    img.setAttribute('aria-hidden', 'true');
+    a.appendChild(img);
+
+    if (withTitle) {
+        const span = document.createElement('span');
+        span.textContent = link.title;
+        a.appendChild(span);
+    }
+
+    a.addEventListener('click', () => trackHeaderLinkClick(link.href, 'header'));
+    return a;
+}
 
 export function initializeHeader() {
     const hamburgerBtn = document.getElementById('hamburger');
     const hamburgerMenu = document.getElementById('hamburgerMenu');
     const closeBtn = hamburgerMenu?.querySelector('.close-menu');
-    
-    // Setup footer link tracking
-    const footer = document.querySelector('.footer');
-    footer?.addEventListener('click', e => {
-        const link = e.target.closest('a');
-        if (link) {
-            trackHeaderLinkClick(link.href, 'footer');
+    const overflowNav = hamburgerMenu?.querySelector('.overflow-links');
+    const quickNav = document.querySelector('.quick-links');
+
+    // Load links config and render
+    getLinksConfig().then(config => {
+        setLinksConfig(config);
+        const base = config.icons.base_path;
+        if (quickNav) {
+            quickNav.innerHTML = '';
+            config.header.quick.forEach(link => {
+                quickNav.appendChild(createLink(link, base));
+            });
         }
-    });
+        if (overflowNav) {
+            overflowNav.innerHTML = '';
+            config.header.overflow.forEach(link => {
+                overflowNav.appendChild(createLink(link, base, true));
+            });
+        }
+        initializeFooter();
+    }).catch(err => console.error(err));
 
     if (hamburgerBtn && hamburgerMenu && closeBtn) {
         const toggleMenu = (show) => {


### PR DESCRIPTION
## Summary
- Read profile and links JSON configs to populate header, footer, and theme
- Map profile colors, typography, and layout to CSS variables and inline styles
- Render header quick links and overflow menu from validated link data

## Testing
- `node --version`
- `node --input-type=module -e "import('./src/js/api.js').then(()=>console.log('api ok'))"`
- `node --input-type=module -e "import('./src/js/ui-header.js').then(()=>console.log('ui-header ok'))"` *(fails: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6335b2a288325b879bc9337287134