### PR TITLE
feat: add tooltips for header and footer icons

### DIFF
--- a/src/js/ui-footer.js
+++ b/src/js/ui-footer.js
@@ -18,6 +18,7 @@ function createFooterIcon(link, basePath) {
     a.target = '_blank';
     a.rel = 'noopener';
     a.setAttribute('aria-label', link.aria);
+    a.title = link.aria;
 
     const img = document.createElement('img');
     img.src = `${basePath}${link.icon}.svg`;

--- a/src/js/ui-header.js
+++ b/src/js/ui-header.js
@@ -12,6 +12,9 @@ function createLink(link, basePath, withTitle = false) {
         a.rel = 'noopener';
     }
     a.setAttribute('aria-label', link.aria);
+    if (!withTitle) {
+        a.title = link.aria;
+    }
 
     const img = document.createElement('img');
     img.src = `${basePath}${link.icon}.svg`;


### PR DESCRIPTION
## Summary
- add title attribute to header quick links so icons show native browser tooltip
- add title attribute to footer icon links using existing aria label metadata

## Testing
- `npm test` (fails: ENOENT package.json)

------
https://chatgpt.com/codex/tasks/task_e_68b8b15885f88325ab359cb6bbfef20e