### PR TITLE
Harden UI and analytics with reduced-motion and font fixes

### DIFF
--- a/config/profile.json
+++ b/config/profile.json
@@ -31,7 +31,20 @@
     "desc_band_bg": "linear-gradient(135deg, var(--brand-primary), var(--brand-secondary))"
   },
 
-   "cards": { "shape": "blocky", "radius_px": 18, "bevel_px": 10 },
+  "cards": { "shape": "blocky", "radius_px": 18, "bevel_px": 10 },
+
+  "fonts": {
+    "primary": {
+      "family": "'Bebas Neue', sans-serif",
+      "weights": ["400"],
+      "css_url": "https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap"
+    },
+    "heading": {
+      "family": "'Merriweather', serif",
+      "weights": ["400", "700"],
+      "css_url": "https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap"
+    }
+  },
 
   "surfaces": {
     "background": { "mode": "video", "video": { "url": "/assets/videos/video.webm", "fit": "cover" } },

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -592,6 +592,10 @@ body[data-gradient="true"] {
     gap: var(--footer-gap);
 }
 
+.footer-links a {
+    text-decoration: none;
+}
+
 .footer-links img {
     width: var(--footer-icon-size);
     height: var(--footer-icon-size);
@@ -773,12 +777,3 @@ body[data-gradient="true"] {
     opacity: 1;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  * {
-    animation: none !important;
-    transition: none !important;
-  }
-  .back-to-top {
-    animation: none !important;
-  }
-}

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -61,6 +61,14 @@
     --description-p-max: 600px;
 }
 
+body {
+    font-family: var(--font-body);
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-heading);
+}
+
 @media (prefers-reduced-motion: reduce) {
   * {
     animation: none !important;
@@ -68,6 +76,10 @@
   }
   .back-to-top {
     animation: none !important;
+  }
+  .card:hover {
+    transform: none;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.3);
   }
 }
 

--- a/src/js/a11y.js
+++ b/src/js/a11y.js
@@ -1,0 +1,1 @@
+export const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;

--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -2,20 +2,37 @@ import { createPayload, initializeBeacon } from './beacon.js';
 
 const QUEUE_KEY = 'cg_queue';
 const memoryQueue = [];
+let storageAvailable = true;
+let storageWarned = false;
 
 function loadQueue() {
     try {
         const stored = sessionStorage.getItem(QUEUE_KEY);
         return stored ? JSON.parse(stored) : memoryQueue;
     } catch (e) {
+        if (!storageWarned) {
+            console.warn('analytics storage unavailable', e);
+            storageWarned = true;
+        }
+        storageAvailable = false;
         return memoryQueue;
     }
 }
 
 function saveQueue() {
+    if (!storageAvailable) {
+        memoryQueue.length = 0;
+        memoryQueue.push(...eventQueue);
+        return;
+    }
     try {
         sessionStorage.setItem(QUEUE_KEY, JSON.stringify(eventQueue));
     } catch (e) {
+        if (!storageWarned) {
+            console.warn('analytics storage unavailable', e);
+            storageWarned = true;
+        }
+        storageAvailable = false;
         memoryQueue.length = 0;
         memoryQueue.push(...eventQueue);
     }

--- a/src/js/head.js
+++ b/src/js/head.js
@@ -7,6 +7,16 @@ export function applyHeadMeta(profile) {
   addLink({ rel:'icon', type:'image/png', sizes:'16x16', href: fav.png16 || '/assets/favicon/favicon-16.png' });
   addLink({ rel:'apple-touch-icon', sizes:'180x180', href: fav.apple || '/assets/favicon/apple-touch-icon.png' });
 
+  // ----- Fonts
+  const fontPrimary = profile?.fonts?.primary;
+  const fontHeading = profile?.fonts?.heading;
+  const fontUrls = [];
+  if (fontPrimary?.css_url) fontUrls.push(fontPrimary.css_url);
+  if (fontHeading?.css_url && fontHeading.css_url !== fontPrimary?.css_url) {
+    fontUrls.push(fontHeading.css_url);
+  }
+  fontUrls.forEach(url => addLink({ rel: 'stylesheet', href: url }));
+
   // ----- TEXT
   const handle = profile?.handle?.trim();
   const desc   = profile?.description?.body?.trim();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -9,8 +9,7 @@ import { getPublicProfile, getPublicCards } from './api.js';
 import { setCards, setProfile } from './state.js';
 import { initializeScroll } from './ui-scroll.js';
 import { renderSocialButtons } from './ui-social.js';
-
-const PRM = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+import { reduceMotion } from './a11y.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   // ---- loader DOM + freeze scroll -----------------------------------------
@@ -135,7 +134,7 @@ function mountLoader() {
   fill.style.borderRadius = '999px';
   fill.style.background = 'var(--creator-gradient, linear-gradient(90deg,#26C6DA,#4361EE))';
   fill.style.transform = 'translateX(-60%)';
-  if (!PRM) fill.style.animation = 'loader-sweep 1.6s ease-in-out infinite';
+  if (!reduceMotion) fill.style.animation = 'loader-sweep 1.6s ease-in-out infinite';
   bar.appendChild(fill);
 
   // keyframes (inline so no CSS edit needed)

--- a/src/js/theme.js
+++ b/src/js/theme.js
@@ -10,49 +10,13 @@ export function applyTheme(profile) {
   const root = document.documentElement;
 
   // --- Fonts ---------------------------------------------------------------
-  const fonts = profile.typography?.fonts;
-
+  const fonts = profile.fonts;
   if (fonts) {
-    const urls = [];
-    const bodyUrl = fonts.primary_url || fonts.body_url;
-    const headingUrl = fonts.heading_url;
-    if (bodyUrl) urls.push(bodyUrl);
-    if (headingUrl && headingUrl !== bodyUrl) urls.push(headingUrl);
-
-    const existing = Array.from(
-      document.head.querySelectorAll('link[data-profile-font]')
-    );
-
-    for (const url of urls) {
-      if (!document.head.querySelector(`link[href="${url}"]`)) {
-        const link = document.createElement('link');
-        link.rel = 'stylesheet';
-        link.href = url;
-        link.dataset.profileFont = 'true';
-        document.head.appendChild(link);
-      }
-    }
-
-    for (const link of existing) {
-      if (!urls.includes(link.href)) link.remove();
-    }
-
-    const bodyFamily =
-      fonts.primary_name ||
-      fonts.body_family ||
-      profile.fonts?.body?.family ||
-      'Inter, system-ui, sans-serif';
-    const headingFamily =
-      fonts.heading_name ||
-      fonts.heading_family ||
-      profile.fonts?.heading?.family ||
-      'var(--font-body)';
-
+    const bodyFamily = fonts.primary?.family || 'Inter, system-ui, sans-serif';
+    const headingFamily = fonts.heading?.family || bodyFamily;
     root.style.setProperty('--font-body', bodyFamily);
     root.style.setProperty('--font-heading', headingFamily);
     document.body.style.fontFamily = 'var(--font-body)';
-  } else {
-    loadFonts(profile.fonts);
   }
 
   // --- Brand tokens ---------------------------------------------------------
@@ -345,9 +309,12 @@ function ensureSurfaceVideo(host, src, className) {
       width: '100%',
       height: '100%',
       objectFit: 'cover',
-      zIndex: '0'
+      zIndex: '-1',
+      pointerEvents: 'none'
     });
-    host.style.position = host.style.position || 'relative';
+    // Preserve existing positioning like fixed or sticky; only adjust if static
+    const pos = getComputedStyle(host).position;
+    if (pos === 'static') host.style.position = 'relative';
     host.prepend(v); // behind content
   }
   if (v.src !== src) v.src = src;
@@ -409,7 +376,7 @@ export function applySurfaceVideos(profile) {
 }
 
 let defaultFontLoaded = false;
-async function loadFonts(fonts) {
+async function loadFonts() {
   // Ensure default Inter is loaded to avoid flashes.
   if (!defaultFontLoaded) {
     const interHref = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap';
@@ -420,29 +387,5 @@ async function loadFonts(fonts) {
       document.head.appendChild(link);
     }
     defaultFontLoaded = true;
-  }
-
-  if (!fonts) return;
-
-  const urls = [];
-  const bodyUrl = fonts.body?.url;
-  const headingUrl = fonts.heading?.url;
-  if (bodyUrl) urls.push(bodyUrl);
-  if (headingUrl && headingUrl !== bodyUrl) urls.push(headingUrl);
-
-  const existing = Array.from(document.head.querySelectorAll('link[data-profile-font]'));
-
-  for (const url of urls) {
-    if (!document.head.querySelector(`link[href="${url}"]`)) {
-      const link = document.createElement('link');
-      link.rel = 'stylesheet';
-      link.href = url;
-      link.dataset.profileFont = 'true';
-      document.head.appendChild(link);
-    }
-  }
-
-  for (const link of existing) {
-    if (!urls.includes(link.href)) link.remove();
   }
 }

--- a/src/js/ui-cards.js
+++ b/src/js/ui-cards.js
@@ -1,5 +1,6 @@
 import { getCards, getCurrentFilter, isCardReported, setCards, setFilter } from './state.js';
 import { trackCardClick, trackCardImpression } from './analytics.js';
+import { reduceMotion } from './a11y.js';
 
 // Constants for virtualization
 const INITIAL_RENDER = 48;  // First batch size
@@ -179,21 +180,23 @@ function createCardElement(card) {
     if (!e.target.closest('.dot-btn')) trackCardClick(uid);
   });
 
-  let pressTimer;
-  cardEl.addEventListener('mousedown', (e) => {
-    if (e.target.closest('.dot-btn')) return;
-    pressTimer = setTimeout(async () => {
-      try {
-        await navigator.clipboard.writeText(targetUrl);
-        fbDiv.classList.add('visible');
-        setTimeout(() => fbDiv.classList.remove('visible'), 1500);
-      } catch {}
-    }, 500);
-  });
+  if (!reduceMotion) {
+    let pressTimer;
+    cardEl.addEventListener('mousedown', (e) => {
+      if (e.target.closest('.dot-btn')) return;
+      pressTimer = setTimeout(async () => {
+        try {
+          await navigator.clipboard.writeText(targetUrl);
+          fbDiv.classList.add('visible');
+          setTimeout(() => fbDiv.classList.remove('visible'), 1500);
+        } catch {}
+      }, 500);
+    });
 
-  ['mouseup', 'mouseleave'].forEach(evt =>
-    cardEl.addEventListener(evt, () => clearTimeout(pressTimer))
-  );
+    ['mouseup', 'mouseleave'].forEach(evt =>
+      cardEl.addEventListener(evt, () => clearTimeout(pressTimer))
+    );
+  }
 
   return cardEl;
 }

--- a/src/js/ui-scroll.js
+++ b/src/js/ui-scroll.js
@@ -1,12 +1,18 @@
+import { reduceMotion } from './a11y.js';
+
 export function initializeScroll() {
     const backToTopButton = document.getElementById('backToTop');
     const footer = document.querySelector('.footer');
-    const PRM = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     let stickyTimer;
 
     function setFooterSticky(enable) {
         clearTimeout(stickyTimer);
         if (!footer) return;
+        if (reduceMotion) {
+            footer.style.transition = 'none';
+            footer.classList.toggle('sticky', enable);
+            return;
+        }
         stickyTimer = setTimeout(() => {
             footer.classList.toggle('sticky', enable);
         }, 5000);
@@ -35,7 +41,7 @@ export function initializeScroll() {
     function scrollToTop() {
         window.scrollTo({
             top: 0,
-            behavior: PRM ? 'auto' : 'smooth'
+            behavior: reduceMotion ? 'auto' : 'smooth'
         });
     }
 


### PR DESCRIPTION
## Summary
- add global `reduceMotion` util and respect it in card long-press, scroll, and CSS hover
- guard analytics sessionStorage access and fall back to memory
- wire profile-defined fonts through head/theme and ensure footer icons have no underline
- keep surface background videos behind content
- preserve existing sticky/fixed positioning when injecting surface videos

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba6af1b0c883259a3c1d6fa289fb79