### PR TITLE
Use card_public_hash for card analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
         <div class="modal-content">
             <form id="reportForm">
                 <h2>Report Content</h2>
-                <input type="hidden" id="reportUid" name="uid">
+                <input type="hidden" id="reportCardHash" name="card_public_hash">
                 <input type="text" id="reportName" name="name" placeholder="Name (optional)">
                 <input type="email" id="reportEmail" name="email" placeholder="Email (optional)">
                 <input type="text" id="reportType" name="type" readonly>

--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -114,16 +114,16 @@ export function trackPageView() {
     }, 2000);
 }
 
-export function trackCardImpression(uid) {
+export function trackCardImpression(cardPublicHash) {
     trackEvent('card_impression', {
-        uid,
+        card_public_hash: cardPublicHash,
         dwell_time: totalDwellTime
     });
 }
 
-export function trackCardClick(uid) {
+export function trackCardClick(cardPublicHash) {
     trackEvent('card_click', {
-        uid,
+        card_public_hash: cardPublicHash,
         dwell_time: totalDwellTime
     });
 }
@@ -136,17 +136,17 @@ export function trackHeaderLinkClick(href, source = 'header') {
     });
 }
 
-export function trackReportOpen(uid, reason) {
+export function trackReportOpen(cardPublicHash, reason) {
     trackEvent('report_open', {
-        uid,
+        card_public_hash: cardPublicHash,
         reason,
         dwell_time: totalDwellTime
     });
 }
 
-export function trackReportSubmit(uid, reportData) {
+export function trackReportSubmit(cardPublicHash, reportData) {
     trackEvent('report_submit', {
-        uid,
+        card_public_hash: cardPublicHash,
         report_type: reportData.type,
         message: reportData.message,
         contact: reportData.contact,
@@ -167,8 +167,8 @@ export function initializeAnalytics() {
         (entries) => {
             entries.forEach(entry => {
                 if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
-                    const uid = entry.target.dataset.uid;
-                    if (uid) trackCardImpression(uid);
+                    const cardPublicHash = entry.target.dataset.cardPublicHash;
+                    if (cardPublicHash) trackCardImpression(cardPublicHash);
                     observer.unobserve(entry.target);
                 }
             });
@@ -177,7 +177,7 @@ export function initializeAnalytics() {
     );
 
     // Observe all cards
-    document.querySelectorAll('.card[data-uid]').forEach(card => {
+    document.querySelectorAll('.card[data-card-public-hash]').forEach(card => {
         observer.observe(card);
     });
 

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -224,12 +224,12 @@ const card_public_hash = [
 // Generate random mock cards
 function generateMockCards(count = 200000) {
     return Array.from({ length: count }, (_, i) => ({
-        uid: card_public_hash[i % card_public_hash.length],
+        card_public_hash: card_public_hash[i % card_public_hash.length],
         imageUrl: mockImages[i % mockImages.length],
         title: mocktitles[i % mocktitles.length],
         targetUrl: 'https://example.com',
         source: i % 2 === 0 ? 'ig' : 'tt',
-        index: i // Add index property, 
+        index: i // Add index property,
     }));
 }
 

--- a/src/js/reports.js
+++ b/src/js/reports.js
@@ -61,10 +61,10 @@ function hideMenu() {
 }
 
 function showModal(reason) {
-    const uid = activeCard.dataset.uid;
-    trackReportOpen(uid, reason);
-    
-    document.getElementById('reportUid').value = uid;
+    const cardPublicHash = activeCard.dataset.cardPublicHash;
+    trackReportOpen(cardPublicHash, reason);
+
+    document.getElementById('reportCardHash').value = cardPublicHash;
     document.getElementById('reportType').value = reason;
     
     modal.classList.add('visible');
@@ -117,7 +117,7 @@ export function initializeReports() {
         e.preventDefault();
         const formData = new FormData(e.target);
         const reportData = {
-            uid: formData.get('uid'),
+            card_public_hash: formData.get('card_public_hash'),
             type: formData.get('type'),
             message: formData.get('message'),
             contact: {
@@ -125,9 +125,9 @@ export function initializeReports() {
                 email: formData.get('email') || null
             }
         };
-        
-        markCardReported(reportData.uid);
-        trackReportSubmit(reportData.uid, reportData);
+
+        markCardReported(reportData.card_public_hash);
+        trackReportSubmit(reportData.card_public_hash, reportData);
         showSuccess();
     });
 

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -24,7 +24,7 @@ export const getCurrentFilter = () => state.currentFilter;
 export const getCurrentPage = () => state.currentPage;
 export const getProfile = () => state.profile;
 export const getLinksConfig = () => state.linksConfig;
-export const isCardReported = (uid) => state.reportedCards.has(uid);
+export const isCardReported = (cardPublicHash) => state.reportedCards.has(cardPublicHash);
 
 // Setters
 export const setCards = (cards) => {
@@ -46,9 +46,9 @@ export const incrementPage = () => {
 
 import { saveReportedCards } from './beacon.js';
 
-export const markCardReported = (uid) => {
-    logStateChange('markCardReported', { uid });
-    state.reportedCards.add(uid);
+export const markCardReported = (cardPublicHash) => {
+    logStateChange('markCardReported', { card_public_hash: cardPublicHash });
+    state.reportedCards.add(cardPublicHash);
     saveReportedCards(state.reportedCards);
 };
 

--- a/src/js/ui-cards.js
+++ b/src/js/ui-cards.js
@@ -33,7 +33,7 @@ function setupObservers() {
                     img.src = img.dataset.src;
                     delete img.dataset.src;
                 }
-                trackCardImpression(card.dataset.uid);
+                trackCardImpression(card.dataset.cardPublicHash);
                 cardObserver.unobserve(card);
             }
         });
@@ -116,7 +116,7 @@ function isSafeUrl(url) {
 /* ---------------- DOM builders ---------------- */
 
 function createCardElement(card) {
-  const uid = card?.uid || '';
+  const cardPublicHash = card?.card_public_hash || '';
   const targetUrl = card?.targetUrl || '#';
   const title = card?.title || '';
   const imageUrl = card?.imageUrl || '';
@@ -126,7 +126,7 @@ function createCardElement(card) {
   cardEl.className = 'card';
   cardEl.setAttribute('target', '_blank');
   cardEl.setAttribute('rel', 'noopener');
-  cardEl.dataset.uid = uid;
+  cardEl.dataset.cardPublicHash = cardPublicHash;
   cardEl.dataset.source = source;
   cardEl.setAttribute('data-source', source);
   cardEl.setAttribute('href', isSafeUrl(targetUrl) ? targetUrl : '#');
@@ -156,7 +156,7 @@ function createCardElement(card) {
   btn.className = 'icon-btn dot-btn';
   btn.type = 'button';
   btn.setAttribute('aria-label', 'Report or more actions');
-  if (isCardReported(uid)) btn.setAttribute('disabled', '');
+  if (isCardReported(cardPublicHash)) btn.setAttribute('disabled', '');
   btn.textContent = '⋯';
   cardEl.appendChild(btn);
 
@@ -177,7 +177,7 @@ function createCardElement(card) {
   cardEl.appendChild(fbDiv);
 
   cardEl.addEventListener('click', (e) => {
-    if (!e.target.closest('.dot-btn')) trackCardClick(uid);
+    if (!e.target.closest('.dot-btn')) trackCardClick(cardPublicHash);
   });
 
   if (!reduceMotion) {


### PR DESCRIPTION
## Summary
- Track card impressions, clicks and reports using `card_public_hash` instead of `uid`
- Propagate card hash through card elements and reporting flows
- Store reported hashes and adjust analytics observers accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c05b5b512c8325a1312cfa5465b793