### PR TITLE
Add PHP rendering for profile and link data

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,0 +1,87 @@
+<?php
+$profilePath = __DIR__ . '/config/profile.json';
+$linksPath   = __DIR__ . '/config/links.json';
+$profile = json_decode(file_get_contents($profilePath), true);
+$links = json_decode(file_get_contents($linksPath), true);
+function e($str) { return htmlspecialchars($str ?? '', ENT_QUOTES, 'UTF-8'); }
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= e($profile['handle'] ?? 'CreatorGrid') ?> — Your Creative Space</title>
+    <meta name="theme-color" content="<?= e($profile['colors']['page_bg'] ?? '#000000') ?>">
+    <meta name="color-scheme" content="dark">
+    <link rel="stylesheet" href="src/css/tokens.css">
+    <link rel="stylesheet" href="src/css/styles.css">
+    <style>
+        :root {
+            --brand-primary: <?= e($profile['brand']['primary'] ?? '#26C6DA') ?>;
+            --brand-secondary: <?= e($profile['brand']['secondary'] ?? '#4361EE') ?>;
+            --brand-tertiary: <?= e($profile['brand']['tertiary'] ?? '#3A0CA3') ?>;
+            --page-bg: <?= e($profile['colors']['page_bg'] ?? '#121212') ?>;
+        }
+    </style>
+</head>
+<body>
+<header class="header h1">
+    <div class="header-content">
+        <div class="branding">
+            <?php $logo = $profile['assets']['favicon']['png32'] ?? ''; ?>
+            <img id="logo" src="<?= e($logo) ?>" alt="">
+            <span id="handle"><?= e($profile['handle']) ?></span>
+        </div>
+        <nav class="header-links">
+            <?php foreach ($links['header']['quick'] ?? [] as $link): ?>
+                <a href="<?= e($link['href']) ?>" aria-label="<?= e($link['aria']) ?>">
+                    <img src="<?= e(($links['icons']['base_path'] ?? '') . $link['icon'] . '.svg') ?>" alt="">
+                </a>
+            <?php endforeach; ?>
+        </nav>
+        <button id="hamburger" aria-controls="hamburgerMenu" aria-expanded="false" aria-label="Menu">☰</button>
+    </div>
+    <div id="hamburgerMenu" role="menu" aria-hidden="true">
+        <button class="close-menu" aria-label="Close menu">✕</button>
+        <div class="menu-links">
+            <?php foreach ($links['header']['overflow'] ?? [] as $link): ?>
+                <a href="<?= e($link['href']) ?>" title="<?= e($link['title']) ?>" aria-label="<?= e($link['aria']) ?>">
+                    <img src="<?= e(($links['icons']['base_path'] ?? '') . $link['icon'] . '.svg') ?>" alt="">
+                    <span><?= e($link['title']) ?></span>
+                </a>
+            <?php endforeach; ?>
+        </div>
+    </div>
+</header>
+<div class="description style-1 align-<?= e($profile['layout']['description_align'] ?? 'center') ?>" data-sticky="<?= !empty($profile['description']['sticky']) ? 'true' : 'false' ?>">
+    <h1><?= e($profile['description']['title']) ?></h1>
+    <p><?= e($profile['description']['body']) ?></p>
+    <?php if (!empty($profile['description']['marketing_link']['show'])): ?>
+        <a href="/signup" class="create-link"><em><?= e($profile['description']['marketing_link']['text']) ?></em></a>
+    <?php endif; ?>
+</div>
+<div id="social-cta" class="filters" role="tablist" hidden></div>
+<main id="grid" class="grid" aria-live="polite"></main>
+<footer class="footer">
+    <div class="footer-links">
+        <?php foreach ($links['footer']['icons'] ?? [] as $icon): ?>
+            <a href="<?= e($icon['href']) ?>" aria-label="<?= e($icon['aria']) ?>">
+                <img src="<?= e(($links['icons']['base_path'] ?? '') . $icon['icon'] . '.svg') ?>" alt="">
+            </a>
+        <?php endforeach; ?>
+        <?php foreach ($links['footer']['text_links'] ?? [] as $text): ?>
+            <?php if (!isset($text['show']) || $text['show']): ?>
+                <a href="<?= e($text['href']) ?>"><?= e($text['label']) ?></a>
+            <?php endif; ?>
+        <?php endforeach; ?>
+    </div>
+    <div class="footer-legal"><?= e($links['footer']['disclaimer'] ?? '') ?></div>
+    <div class="copyright">&copy; <?= date('Y') ?> <?= e($profile['handle']) ?></div>
+</footer>
+<script>
+window.profileData = <?= json_encode($profile, JSON_UNESCAPED_SLASHES) ?>;
+window.linksData = <?= json_encode($links, JSON_UNESCAPED_SLASHES) ?>;
+</script>
+<script type="module" src="src/js/main.js"></script>
+</body>
+</html>

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -235,6 +235,10 @@ function generateMockCards(count = 200000) {
 
 // Mock API calls
 export async function getPublicProfile() {
+    // Allow preloaded data from server-rendered pages
+    if (typeof window !== 'undefined' && window.profileData) {
+        return window.profileData;
+    }
     console.log('Fetching public profile...');
     const res = await fetch('/config/profile.json');
     if (!res.ok) throw new Error('Failed to load profile');
@@ -242,6 +246,10 @@ export async function getPublicProfile() {
 }
 
 export async function getLinksConfig() {
+    // Allow preloaded data from server-rendered pages
+    if (typeof window !== 'undefined' && window.linksData) {
+        return window.linksData;
+    }
     console.log('Fetching links config...');
     const res = await fetch('/config/links.json');
     if (!res.ok) throw new Error('Failed to load links');

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -13,8 +13,9 @@ import { reduceMotion } from './a11y.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   // ---- loader DOM + freeze scroll -----------------------------------------
-  const unfreeze = freezeScroll();
-  const loader = mountLoader(); // returns {root, logo}
+  const preloadedProfile = typeof window !== 'undefined' && window.profileData;
+  const unfreeze = preloadedProfile ? () => {} : freezeScroll();
+  const loader = preloadedProfile ? { root: null, logo: null } : mountLoader();
 
   try {
     // base UI (fonts, header shell, reports)
@@ -22,9 +23,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     initializeHeader();
     initializeReports();
 
-    // fetch
+    // fetch or use preloaded data
     const [profile, cards] = await Promise.all([
-      getPublicProfile(),
+      preloadedProfile ? Promise.resolve(window.profileData) : getPublicProfile(),
       getPublicCards(),
     ]);
 


### PR DESCRIPTION
## Summary
- Add `index.php` to render profile and link data server-side
- Allow `getPublicProfile` and `getLinksConfig` to use preloaded JSON data
- Skip loader and network fetch when profile data is preloaded
- Move PHP entry point to project root and fix asset paths

## Testing
- `php -l index.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0c55ad1ec83258f72638a9ffe52d8