### PR TITLE
Add visitor preview harness

### DIFF
--- a/visitor-preview-harness.html
+++ b/visitor-preview-harness.html
@@ -1,0 +1,381 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Visitor Preview Harness</title>
+<style>
+/* ===== tokens.css ===== */
+:root {
+    /* Brand Colors */
+    --brand-primary: #26C6DA;
+    --brand-secondary: #4361EE;
+    --brand-tertiary: #3A0CA3;
+    --brand-text: #121212;
+
+    /* Creator */
+    --creator-bg: var(--brand-text);
+    --creator-gradient: linear-gradient(135deg, var(--brand-primary), var(--brand-secondary));
+    --creator-card-radius: 18px;
+
+    /* Layout */
+    --grid-max: 1440px;
+    --gap: clamp(1.5rem, 2vw, 2rem);
+
+    /* Typography */
+    --font-body: Inter, system-ui, sans-serif;
+    --font-heading: var(--font-body);
+
+    /* Header */
+    --hdr-h: 64px;
+    --header-bg: rgba(255, 255, 255, 0.1);
+    --header-blur: 15px;
+    --header-bd: rgba(255, 255, 255, 0.1);
+
+    /* Footer */
+    --ftr-h: 80px;
+    --footer-bg: rgba(0, 0, 0, 0.2);
+    --footer-blur: var(--header-blur);
+    --footer-bd: var(--header-bd);
+    --footer-padding-y: 2rem;
+    --footer-icon-size: 20px;
+    --footer-gap: 1rem;
+    --footer-link-color: rgba(255, 255, 255, 0.8);
+
+    /* Card */
+    --card-bg: #1e1e1e;
+    --card-title-size: clamp(0.9rem, 2vw, 1.2rem);
+    --card-title-weight: 600;
+    --card-title-lines: 2;
+    --card-bevel: 10px;
+    --rim: rgba(255, 255, 255, 0.5);
+
+    /* Text */
+    --text: rgba(255, 255, 255, 0.9);
+    --text-muted: rgba(255, 255, 255, 0.6);
+    --accent: var(--brand-primary);
+
+    /* Misc */
+    --logo-size: 64px;
+    --modal-bg: var(--creator-bg);
+    --modal-bd: rgba(255, 255, 255, 0.1);
+    --menu-bg: rgba(30, 30, 30, 0.95);
+    --menu-hover: rgba(255, 255, 255, 0.1);
+
+    /* Description sizing */
+    --description-max-width: clamp(320px, 60ch, 720px);
+    --description-margin: 2rem auto;
+    --description-content-max: 720px;
+    --description-p-max: 600px;
+}
+
+body {font-family: var(--font-body);}
+
+h1, h2, h3, h4, h5, h6 {font-family: var(--font-heading);}
+
+@media (prefers-reduced-motion: reduce) {
+  * {animation: none !important;transition: none !important;}
+  .card:hover {transform: none;box-shadow: 0 2px 6px rgba(0,0,0,0.3);}
+}
+
+/* ===== base layout ===== */
+*{margin:0;padding:0;box-sizing:border-box;}
+html{font-size:clamp(8px,1.2vw,16px);}
+body{line-height:1.5;color:var(--text);background:var(--creator-bg);min-height:100vh;display:flex;flex-direction:column;}
+
+/* harness controls */
+#controls{padding:0.5rem;background:#000;color:#fff;display:flex;gap:1rem;align-items:center;}
+#controls label{font-size:0.8rem;}
+.tabs{display:flex;gap:0.5rem;padding:0.5rem;background:#111;}
+.tabs button{background:#222;color:#fff;border:1px solid #444;padding:0.4rem 0.8rem;cursor:pointer;}
+.tabs button[aria-selected="true"]{background:#555;}
+.tab{display:none;}
+.tab.active{display:block;}
+
+/* canvas / stage */
+.stage{position:relative;width:100%;aspect-ratio:16/9;border:1px solid #555;overflow:hidden;}
+.stage .screen{position:absolute;top:0;left:0;display:flex;flex-direction:column;min-height:100%;}
+.checkerboard{background-size:20px 20px;background-position:0 0,10px 10px;background-image:linear-gradient(45deg,#666 25%,transparent 25%,transparent 75%,#666 75%,#666),linear-gradient(45deg,#666 25%,transparent 25%,transparent 75%,#666 75%,#666);}
+
+/* header */
+.header{height:var(--hdr-h);padding:0 max(1rem,calc((100% - var(--grid-max)) / 2));background:var(--header-bg);backdrop-filter:blur(var(--header-blur));-webkit-backdrop-filter:blur(var(--header-blur));border-bottom:1px solid var(--header-bd);}
+.header-content{max-width:var(--grid-max);height:var(--hdr-h);margin:0 auto;display:grid;grid-template-columns:auto 1fr auto;align-items:center;column-gap:1rem;}
+.branding{display:flex;align-items:center;gap:1rem;}
+#logo{width:var(--logo-size);height:var(--logo-size);border-radius:12px;object-fit:cover;}
+#handle{font-size:clamp(2rem,4vw,2.25rem);font-weight:600;}
+.header-links{display:flex;align-items:center;gap:1rem;}
+.header-links a{display:flex;align-items:center;color:var(--text);text-decoration:none;}
+.header-links img{width:clamp(24px,6vw,32px);height:clamp(24px,6vw,32px);}
+#hamburger{padding:1rem;margin-left:1rem;background:none;border:none;color:var(--text);cursor:pointer;font-size:clamp(2rem,8vw,2.5rem);}
+
+/* description */
+.description{max-width:var(--description-max-width);margin:var(--description-margin);padding:clamp(1rem,5vw,2rem);border-radius:var(--description-border-radius);color:white;position:relative;z-index:200;}
+.description > * {max-width:var(--description-content-max);margin-left:auto;margin-right:auto;}
+.description h1{font-size:clamp(1.2rem,5vw,2rem);margin-bottom:1rem;font-weight:800;}
+.description p{font-size:clamp(0.9rem,3vw,1.1rem);opacity:0.9;max-width:var(--description-p-max);margin:0 auto;}
+.description.style-1{background:var(--creator-gradient);border:var(--description-border);}
+.description.align-center{text-align:center;}
+.description .create-link{display:inline-block;margin-top:1rem;color:var(--brand-text);text-decoration:none;font-size:0.9rem;opacity:0.8;transition:opacity 0.2s ease;}
+.description .create-link:hover{opacity:1;}
+
+/* grid & cards */
+.grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--gap);max-width:var(--grid-max);width:100%;margin:0 auto;padding:clamp(16px,4vw,24px);box-sizing:border-box;}
+.card{display:flex;flex-direction:column;text-decoration:none;color:inherit;border-radius:var(--creator-card-radius);overflow:hidden;background:var(--card-bg);box-shadow:0 2px 6px rgba(0,0,0,0.3);transition:transform 0.2s ease,box-shadow 0.2s ease;position:relative;}
+.card:hover{transform:translateY(-2px);box-shadow:0 4px 12px rgba(0,0,0,0.4);}
+.card:active{box-shadow:0 0 0 2px var(--rim) inset;}
+.thumb-wrap{position:relative;width:100%;aspect-ratio:742/960;overflow:hidden;}
+.thumb{width:100%;height:100%;object-fit:cover;}
+.card-footer{padding:12px;background:var(--card-bg);}
+.title{margin:0;font-size:var(--card-title-size);font-weight:var(--card-title-weight);line-height:1.35;display:-webkit-box;-webkit-line-clamp:var(--card-title-lines);-webkit-box-orient:vertical;overflow:hidden;min-height:calc(var(--card-title-lines)*1.35em);max-height:calc(var(--card-title-lines)*1.35em);}
+.icon-btn.dot-btn{position:absolute;top:0.5rem;right:0.5rem;width:32px;height:32px;border-radius:50%;border:none;background:rgba(0,0,0,0.5);color:white;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:all 0.2s ease;z-index:5;}
+.copy-feedback{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%) scale(0.8);background:rgba(0,0,0,0.85);color:white;padding:0.5rem 1rem;border-radius:8px;font-size:0.9rem;pointer-events:none;opacity:0;transition:all 0.3s ease;}
+.copy-feedback.visible{opacity:1;transform:translate(-50%,-50%) scale(1);}
+
+/* footer */
+.footer{margin-top:auto;padding:var(--footer-padding-y) max(1rem, calc((100% - var(--grid-max)) / 2));background:var(--footer-bg);backdrop-filter:blur(var(--footer-blur));-webkit-backdrop-filter:blur(var(--footer-blur));border-top:1px solid var(--footer-bd);text-align:center;}
+.footer-links{display:flex;justify-content:center;gap:var(--footer-gap);}
+.footer-links a{text-decoration:none;}
+.footer-links img{width:var(--footer-icon-size);height:var(--footer-icon-size);transition:transform 0.2s;}
+.footer-links a:hover img{transform:scale(1.1);}
+.footer-legal{display:flex;justify-content:center;gap:2rem;font-size:var(--footer-font-size,0.95rem);font-weight:var(--footer-font-weight,500);}
+.footer-legal a{color:var(--footer-link-color);text-decoration:none;}
+.copyright{color:var(--text-muted);font-size:0.8rem;padding-bottom:0.5rem;}
+</style>
+<script>
+const config = {
+  profile: {
+    handle: "Take_Down",
+    assets: {
+      favicon: { png32: "/assets/logo.png" },
+      social_image: "/assets/og/default-og.png"
+    },
+    colors: {
+      page_bg: "#121212",
+      gradient: "linear-gradient(135deg, var(--brand-primary), var(--brand-secondary))"
+    },
+    cards: { radius_px: 18 },
+    description: {
+      visible: true,
+      sticky: false,
+      width: "mid",
+      title: "Welcome to my creative space",
+      body: "Explore my latest content from Instagram and TikTok. Feel free to browse through my curated collection of posts and connect with me on various social platforms",
+      marketing_link: { show: true, text: "Create your own creative space" }
+    }
+  },
+  links: {
+    icons: { base_path: "/assets/icons/" },
+    header: {
+      quick: [
+        { icon: "social-instagram_icon", href: "https://instagram.com/your", aria: "Instagram" },
+        { icon: "social-tiktok_icon", href: "https://tiktok.com/@your", aria: "TikTok" },
+        { icon: "web_icon", href: "https://esegames.com", aria: "Esegames" }
+      ]
+    },
+    footer: {
+      visible: true,
+      icons: [
+        { icon: "social-whatsapp_icon", href: "https://wa.me/...", aria: "WhatsApp" },
+        { icon: "social-instagram_icon", href: "https://instagram.com/...", aria: "Instagram" },
+        { icon: "social-tiktok_icon", href: "https://tiktok.com/@...", aria: "TikTok" },
+        { icon: "social-youtube_icon", href: "https://youtube.com/...", aria: "YouTube" },
+        { icon: "social-linkedin_icon", href: "https://linkedin.com/...", aria: "LinkedIn" }
+      ],
+      text_links: [
+        { label: "Privacy Policy", href: "/privacy", fixed: true },
+        { label: "Create Account", href: "/signup", show: false }
+      ],
+      disclaimer: "All logos are property of their respective owners."
+    }
+  }
+};
+
+function applyTheme(){
+  document.documentElement.style.setProperty('--creator-card-radius', config.profile.cards.radius_px + 'px');
+  document.documentElement.style.setProperty('--creator-bg', config.profile.colors.page_bg);
+  document.documentElement.style.setProperty('--creator-gradient', config.profile.colors.gradient);
+}
+
+function createEl(tag, cls){const el=document.createElement(tag);if(cls)el.className=cls;return el;}
+
+function renderHeader(parent){
+  const header=createEl('header','header h1');
+  const content=createEl('div','header-content');
+  const branding=createEl('div','branding');
+  const logo=document.createElement('img');logo.id='logo';logo.src=config.profile.assets.favicon.png32;logo.alt='';
+  const handle=document.createElement('span');handle.id='handle';handle.textContent='@'+config.profile.handle;
+  branding.append(logo,handle);
+  const nav=createEl('nav','header-links');
+  config.links.header.quick.slice(0,3).forEach(link=>{
+    const a=document.createElement('a');a.href=link.href;a.target='_blank';
+    const img=document.createElement('img');img.src=config.links.icons.base_path+link.icon+'.svg';img.alt=link.aria;
+    a.appendChild(img);nav.appendChild(a);
+  });
+  const hamburger=document.createElement('button');hamburger.id='hamburger';hamburger.setAttribute('aria-label','Menu');hamburger.textContent='☰';
+  content.append(branding,nav,hamburger);header.appendChild(content);parent.appendChild(header);
+}
+
+function renderDescription(parent){
+  if(!config.profile.description.visible) return;
+  const d=createEl('div','description style-1 align-center');
+  d.setAttribute('data-sticky', config.profile.description.sticky);
+  const h1=createEl('h1');h1.textContent=config.profile.description.title;d.appendChild(h1);
+  const p=createEl('p');p.textContent=config.profile.description.body;d.appendChild(p);
+  if(config.profile.description.marketing_link.show){
+    const a=document.createElement('a');a.href='/signup';a.className='create-link';const em=document.createElement('em');em.textContent=config.profile.description.marketing_link.text;a.appendChild(em);d.appendChild(a);
+  }
+  parent.appendChild(d);
+}
+
+function renderCards(parent){
+  const main=createEl('main','grid');
+  for(let i=1;i<=4;i++){
+    const card=createEl('a','card');card.href='#';card.target='_blank';
+    const tw=createEl('div','thumb-wrap');
+    const img=createEl('img','thumb');img.src=config.profile.assets.social_image;img.alt='';
+    tw.appendChild(img);card.appendChild(tw);
+    const btn=createEl('button','icon-btn dot-btn');btn.type='button';btn.textContent='⋯';card.appendChild(btn);
+    const footer=createEl('div','card-footer');const h3=createEl('h3','title');h3.textContent='Card '+i;footer.appendChild(h3);card.appendChild(footer);
+    const fb=createEl('div','copy-feedback');fb.textContent='Link copied!';card.appendChild(fb);
+    main.appendChild(card);
+  }
+  parent.appendChild(main);
+}
+
+function renderFooter(parent){
+  if(!config.links.footer.visible) return;
+  const footer=createEl('footer','footer');
+  const icons=createEl('div','footer-links');
+  config.links.footer.icons.forEach(link=>{
+    const a=document.createElement('a');a.href=link.href;a.target='_blank';
+    const img=createEl('img');img.src=config.links.icons.base_path+link.icon+'.svg';img.alt=link.aria;a.appendChild(img);icons.appendChild(a);
+  });
+  const text=createEl('div','footer-legal');
+  config.links.footer.text_links.forEach(t=>{if(t.show===false)return;const a=document.createElement('a');a.href=t.href;a.textContent=t.label;text.appendChild(a);});
+  const copy=createEl('div','copyright');copy.textContent=config.links.footer.disclaimer;
+  footer.append(icons,text,copy);parent.appendChild(footer);
+}
+
+function fitStage(stage){
+  const screen=stage.querySelector('.screen');
+  if(!screen) return;
+  const width=screen.offsetWidth;
+  const height=screen.offsetHeight;
+  const scale=Math.min(stage.clientWidth/width, stage.clientHeight/height);
+  screen.style.transform=`scale(${scale})`;
+  screen.style.transformOrigin='top left';
+  const offsetX=(stage.clientWidth - width*scale)/2;
+  const offsetY=(stage.clientHeight - height*scale)/2;
+  screen.style.left=offsetX+'px';
+  screen.style.top=offsetY+'px';
+}
+
+function renderAll(){
+  applyTheme();
+  const stage=document.getElementById('stage-all');
+  stage.innerHTML='';
+  const screen=createEl('div','screen');
+  renderHeader(screen);
+  renderDescription(screen);
+  renderCards(screen);
+  renderFooter(screen);
+  stage.appendChild(screen);
+  requestAnimationFrame(()=>fitStage(stage));
+}
+
+function renderHeaderStage(){
+  const stage=document.getElementById('stage-header');
+  stage.innerHTML='';
+  const screen=createEl('div','screen');
+  renderHeader(screen);
+  stage.appendChild(screen);
+  requestAnimationFrame(()=>fitStage(stage));
+}
+
+function renderFooterStage(){
+  const stage=document.getElementById('stage-footer');
+  stage.innerHTML='';
+  const screen=createEl('div','screen');
+  renderFooter(screen);
+  stage.appendChild(screen);
+  requestAnimationFrame(()=>fitStage(stage));
+}
+
+function renderDescriptionStage(){
+  const stage=document.getElementById('stage-description');
+  stage.innerHTML='';
+  const screen=createEl('div','screen');
+  renderDescription(screen);
+  stage.appendChild(screen);
+  requestAnimationFrame(()=>fitStage(stage));
+}
+
+function renderCardsStage(){
+  const stage=document.getElementById('stage-cards');
+  stage.innerHTML='';
+  const screen=createEl('div','screen');
+  renderCards(screen);
+  stage.appendChild(screen);
+  requestAnimationFrame(()=>fitStage(stage));
+}
+
+function renderBackgroundStage(){
+  const bg=document.getElementById('stage-background');
+  if(config.profile.surfaces && config.profile.surfaces.background && config.profile.surfaces.background.mode==='gradient'){
+    bg.style.background=config.profile.colors.gradient;
+  } else {
+    bg.style.background=config.profile.colors.page_bg;
+  }
+}
+
+function initTabs(){
+  document.querySelectorAll('.tabs button').forEach(btn=>{
+    btn.addEventListener('click',()=>{
+      document.querySelectorAll('.tabs button').forEach(b=>b.setAttribute('aria-selected','false'));
+      btn.setAttribute('aria-selected','true');
+      document.querySelectorAll('.tab').forEach(t=>t.classList.remove('active'));
+      document.getElementById(btn.dataset.tab).classList.add('active');
+    });
+  });
+}
+
+function initControls(){
+  document.getElementById('radius').value=config.profile.cards.radius_px;
+  document.getElementById('apply').addEventListener('click',()=>{
+    config.profile.cards.radius_px=parseInt(document.getElementById('radius').value,10) || 0;
+    renderAll();renderHeaderStage();renderFooterStage();renderDescriptionStage();renderCardsStage();
+  });
+}
+
+document.addEventListener('DOMContentLoaded',()=>{
+  renderAll();
+  renderHeaderStage();
+  renderFooterStage();
+  renderDescriptionStage();
+  renderCardsStage();
+  renderBackgroundStage();
+  initTabs();
+  initControls();
+});
+</script>
+</head>
+<body>
+<div id="controls">
+  <label>Card Radius <input type="number" id="radius" min="0" max="50"></label>
+  <button id="apply">Apply</button>
+</div>
+<div class="tabs">
+  <button aria-selected="true" data-tab="tab-all">All</button>
+  <button aria-selected="false" data-tab="tab-header">Header</button>
+  <button aria-selected="false" data-tab="tab-footer">Footer</button>
+  <button aria-selected="false" data-tab="tab-description">Description</button>
+  <button aria-selected="false" data-tab="tab-cards">Cards</button>
+  <button aria-selected="false" data-tab="tab-background">Background</button>
+</div>
+<div id="tab-all" class="tab active"><div id="stage-all" class="stage checkerboard"></div></div>
+<div id="tab-header" class="tab"><div id="stage-header" class="stage checkerboard" style="height:40vh"></div></div>
+<div id="tab-footer" class="tab"><div id="stage-footer" class="stage checkerboard" style="height:40vh"></div></div>
+<div id="tab-description" class="tab"><div id="stage-description" class="stage checkerboard" style="height:50vh"></div></div>
+<div id="tab-cards" class="tab"><div id="stage-cards" class="stage checkerboard" style="height:60vh"></div></div>
+<div id="tab-background" class="tab"><div id="stage-background" class="stage" style="height:60vh"></div></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- inline repo tokens and component styles in visitor-preview-harness.html
- render header, description, cards and footer inside 16:9 canvas with scaling to prevent scroll
- anchor footer within canvas and provide tabbed views for each surface

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3df1e136c8325b4098ad259106348