### PR TITLE
fix stage scaling for visitor preview harness

### DIFF
--- a/visitor-preview-harness.html
+++ b/visitor-preview-harness.html
@@ -93,7 +93,7 @@ body{line-height:1.5;color:var(--text);background:var(--creator-bg);min-height:1
 
 /* canvas / stage */
 .stage{position:relative;width:100%;aspect-ratio:16/9;border:1px solid #555;overflow:hidden;}
-.stage .screen{position:absolute;top:0;left:0;display:flex;flex-direction:column;min-height:100%;}
+.stage .screen{position:absolute;top:0;left:0;display:flex;flex-direction:column;width:1440px;height:810px;}
 .checkerboard{background-size:20px 20px;background-position:0 0,10px 10px;background-image:linear-gradient(45deg,#666 25%,transparent 25%,transparent 75%,#666 75%,#666),linear-gradient(45deg,#666 25%,transparent 25%,transparent 75%,#666 75%,#666);}
 
 /* header */
@@ -259,8 +259,8 @@ function renderFooter(parent){
 function fitStage(stage){
   const screen=stage.querySelector('.screen');
   if(!screen) return;
-  const width=screen.offsetWidth;
-  const height=screen.offsetHeight;
+  const width=1440;
+  const height=810;
   const scale=Math.min(stage.clientWidth/width, stage.clientHeight/height);
   screen.style.transform=`scale(${scale})`;
   screen.style.transformOrigin='top left';


### PR DESCRIPTION
## Summary
- set fixed 1440×810 screen dimensions in visitor preview harness
- scale stage based on fixed snapshot size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c551b64dcc8325ab2039c395b6ab6b