### PR TITLE
Restore card grid CSS in visitor preview harness

### DIFF
--- a/visitor-preview-harness.html
+++ b/visitor-preview-harness.html
@@ -123,10 +123,13 @@ body{line-height:1.5;color:var(--text);background:var(--creator-bg);min-height:1
 .card:hover{transform:translateY(-2px);box-shadow:0 4px 12px rgba(0,0,0,0.4);}
 .card:active{box-shadow:0 0 0 2px var(--rim) inset;}
 .thumb-wrap{position:relative;width:100%;aspect-ratio:742/960;overflow:hidden;}
-.thumb{width:100%;height:100%;object-fit:cover;}
+.thumb-wrap .ph,.thumb-wrap .thumb{position:absolute;inset:0;}
+.thumb-wrap .ph svg{width:100%;height:100%;display:block;}
+.thumb-wrap .thumb{width:100%;height:100%;object-fit:cover;z-index:1;}
 .card-footer{padding:12px;background:var(--card-bg);}
 .title{margin:0;font-size:var(--card-title-size);font-weight:var(--card-title-weight);line-height:1.35;display:-webkit-box;-webkit-line-clamp:var(--card-title-lines);-webkit-box-orient:vertical;overflow:hidden;min-height:calc(var(--card-title-lines)*1.35em);max-height:calc(var(--card-title-lines)*1.35em);}
 .icon-btn.dot-btn{position:absolute;top:0.5rem;right:0.5rem;width:32px;height:32px;border-radius:50%;border:none;background:rgba(0,0,0,0.5);color:white;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:all 0.2s ease;z-index:5;}
+.icon-btn:hover{transform:scale(1.1);}
 .copy-feedback{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%) scale(0.8);background:rgba(0,0,0,0.85);color:white;padding:0.5rem 1rem;border-radius:8px;font-size:0.9rem;pointer-events:none;opacity:0;transition:all 0.3s ease;}
 .copy-feedback.visible{opacity:1;transform:translate(-50%,-50%) scale(1);}
 


### PR DESCRIPTION
## Summary
- Inline card grid and thumb styles in preview harness to mirror styles.css
- Add icon button hover effect for card actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c551d163b8832599c9047be746b74d