### PR TITLE
Use relative asset paths in preview harness

### DIFF
--- a/visitor-preview-harness.html
+++ b/visitor-preview-harness.html
@@ -145,8 +145,8 @@ const config = {
   profile: {
     handle: "Take_Down",
     assets: {
-      favicon: { png32: "/assets/logo.png" },
-      social_image: "/assets/og/default-og.png"
+      favicon: { png32: "./assets/logo.png" },
+      social_image: "./assets/og/default-og.png"
     },
     colors: {
       page_bg: "#121212",
@@ -163,7 +163,7 @@ const config = {
     }
   },
   links: {
-    icons: { base_path: "/assets/icons/" },
+    icons: { base_path: "./assets/icons/" },
     header: {
       quick: [
         { icon: "social-instagram_icon", href: "https://instagram.com/your", aria: "Instagram" },


### PR DESCRIPTION
## Summary
- update visitor preview harness to reference assets via `./assets/` paths to match production

## Testing
- `npm test`
- `node -e "const fs=require('fs');const icons=['social-instagram_icon','social-tiktok_icon','web_icon','social-whatsapp_icon','social-youtube_icon','social-linkedin_icon'];icons.forEach(i=>fs.accessSync('assets/icons/'+i+'.svg'));console.log('All icons found');"`


------
https://chatgpt.com/codex/tasks/task_e_68c551f8d2f48325b8efd440b3d63ff8