### PR TITLE
Fix glass rendering and correct stage heights

### DIFF
--- a/visitor-preview-harness.html
+++ b/visitor-preview-harness.html
@@ -363,36 +363,71 @@ function applySurface(el, surf, fallback){
   el.style.webkitBackdropFilter='';
   if(!surf) return;
   const layers=[];
-  
-  // If it's glass mode, apply the background effect first
+
+  // Glass mode needs special handling to show the underlying surface
   if(surf.mode === 'glass') {
-    // Get the parent background if available
-    const parentBg = config.profile.surfaces.background;
-    if(parentBg && parentBg.mode) {
-      switch(parentBg.mode) {
-        case 'gradient':
-          layers.push(config.profile.colors.gradient);
-          break;
-        case 'solid':
-          layers.push(config.profile.colors.page_bg);
-          break;
-        case 'image':
-          if(parentBg.image?.url) {
-            layers.push(`url(${parentBg.image.url}) ${parentBg.image.pos || 'center'}/${parentBg.image.fit || 'cover'} no-repeat`);
-          }
-          break;
+    if(surf.video && surf.video.url){
+      el.style.background='transparent';
+      const vid=createEl('video','video-bg');
+      vid.src=surf.video.url;
+      vid.autoplay=true;
+      vid.muted=true;
+      vid.loop=true;
+      vid.playsInline=true;
+      vid.style.objectFit=surf.video.fit||'cover';
+      vid.style.objectPosition=surf.video.pos||'center';
+      el.appendChild(vid);
+    } else if(surf.image && surf.image.url){
+      const fit=surf.image.fit||'cover';
+      const pos=surf.image.pos||'center';
+      layers.push(`url(${surf.image.url}) ${pos}/${fit} no-repeat`);
+    } else {
+      const parentBg = config.profile.surfaces.background;
+      if(parentBg && parentBg.mode){
+        switch(parentBg.mode){
+          case 'gradient':
+            layers.push(config.profile.colors.gradient);break;
+          case 'solid':
+            layers.push(config.profile.colors.page_bg);break;
+          case 'image':
+            if(parentBg.image?.url){
+              layers.push(`url(${parentBg.image.url}) ${parentBg.image.pos||'center'}/${parentBg.image.fit||'cover'} no-repeat`);
+            }
+            break;
+          case 'video':
+            if(parentBg.video?.url){
+              el.style.background='transparent';
+              const vid=createEl('video','video-bg');
+              vid.src=parentBg.video.url;
+              vid.autoplay=true;
+              vid.muted=true;
+              vid.loop=true;
+              vid.playsInline=true;
+              vid.style.objectFit=parentBg.video.fit||'cover';
+              vid.style.objectPosition=parentBg.video.pos||'center';
+              el.appendChild(vid);
+            }
+            break;
+        }
       }
     }
+    if(surf.glass){
+      layers.unshift(`rgba(255,255,255,${surf.glass.opacity||0})`);
+      el.style.backdropFilter=`blur(${surf.glass.blur_px||0}px)`;
+      el.style.webkitBackdropFilter=`blur(${surf.glass.blur_px||0}px)`;
+    }
+    if(layers.length) el.style.background=layers.join(', ');
+    return;
   }
-  
+
   switch(surf.mode){
     case 'gradient':
       layers.push(config.profile.colors.gradient);
       break;
     case 'solid':
-      layers.push(surf === config.profile.surfaces.background ? 
+      layers.push(surf === config.profile.surfaces.background ?
         config.profile.colors.background_bg || config.profile.colors.page_bg :
-        surf === config.profile.surfaces.header ? 
+        surf === config.profile.surfaces.header ?
           config.profile.colors.header_bg || config.profile.colors.page_bg :
           surf === config.profile.surfaces.footer ?
             config.profile.colors.footer_bg || config.profile.colors.page_bg :
@@ -418,21 +453,10 @@ function applySurface(el, surf, fallback){
         vid.loop=true;
         vid.playsInline=true;
         vid.style.objectFit=surf.video.fit||'cover';
+        vid.style.objectPosition=surf.video.pos||'center';
         el.appendChild(vid);
       }
       break;
-    case 'glass':
-      if(surf.glass){
-        el.style.backdropFilter = `blur(${surf.glass.blur_px || 0}px)`;
-        el.style.webkitBackdropFilter = `blur(${surf.glass.blur_px || 0}px)`;
-        layers.unshift(`rgba(255,255,255,${surf.glass.opacity || 0})`);
-      }
-      break;
-  }
-  if(surf.mode==='glass' && surf.glass){
-    layers.unshift(`rgba(255,255,255,${surf.glass.opacity||0})`);
-    el.style.backdropFilter=`blur(${surf.glass.blur_px||0}px)`;
-    el.style.webkitBackdropFilter=`blur(${surf.glass.blur_px||0}px)`;
   }
   if(layers.length) el.style.background=layers.join(', ');
 }
@@ -539,9 +563,12 @@ function renderHeaderStage(){
   const stage=document.getElementById('stage-header');
   stage.innerHTML='';
   const screen=createEl('div','screen');
+  screen.style.height=config.profile.sizes.header_height_px + 'px';
   renderHeader(screen);
   stage.appendChild(screen);
   fitStage(stage);
+  const scale=stage.clientWidth/1440;
+  stage.style.height=(config.profile.sizes.header_height_px*scale)+'px';
 }
 
 function renderFooterStage(){
@@ -552,7 +579,13 @@ function renderFooterStage(){
   screen.style.justifyContent='flex-end';
   renderFooter(screen);
   stage.appendChild(screen);
+  const surf=screen.querySelector('.surface');
+  surf.style.height='auto';
+  const h=surf.offsetHeight;
+  screen.style.height=h+'px';
   fitStage(stage);
+  const scale=stage.clientWidth/1440;
+  stage.style.height=(h*scale)+'px';
 }
 
 function renderDescriptionStage(){
@@ -562,7 +595,13 @@ function renderDescriptionStage(){
   const screen=createEl('div','screen');
   renderDescription(screen);
   stage.appendChild(screen);
+  const surf=screen.querySelector('.surface');
+  surf.style.height='auto';
+  const h=surf.offsetHeight;
+  screen.style.height=h+'px';
   fitStage(stage);
+  const scale=stage.clientWidth/1440;
+  stage.style.height=(h*scale)+'px';
 }
 
 function renderCardsStage(){


### PR DESCRIPTION
## Summary
- support glass mode with video/image backgrounds and inherited parent background
- size header, footer, and description stages to match profile configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c719e2c1e4832582e107ea779104b0